### PR TITLE
Update database ref method to pass included path param

### DIFF
--- a/lib/services/firebase-admin-database.service.ts
+++ b/lib/services/firebase-admin-database.service.ts
@@ -19,7 +19,7 @@ export class FirebaseDatabaseService implements admin.database.Database {
     return this.database.goOnline();
   }
   ref(path?: string | admin.database.Reference): admin.database.Reference {
-    return this.database.ref();
+    return this.database.ref(path);
   }
   refFromURL(url: string): admin.database.Reference {
     return this.database.refFromURL(url);


### PR DESCRIPTION
Not sure if this was just an oversight or intentional. I was trying to specify the path when calling `ref` and it wasn't working. Upon looking at the service it's clear that it would never work as the path param is never passed to the firebase `ref` method.