### PR TITLE
Add  listVersions, rollback, getTemplateAtVersion

### DIFF
--- a/lib/services/firebase-admin-remote-config.service.ts
+++ b/lib/services/firebase-admin-remote-config.service.ts
@@ -15,18 +15,34 @@ export class FirebaseRemoteConfigService implements admin.remoteConfig.RemoteCon
   getTemplate(): Promise<admin.remoteConfig.RemoteConfigTemplate> {
     return this.remoteConfig.getTemplate();
   }
+
+  getTemplateAtVersion(versionNumber: number | string): Promise<admin.remoteConfig.RemoteConfigTemplate> {
+    return this.remoteConfig.getTemplateAtVersion(versionNumber);
+  }
+
   validateTemplate(
     template: admin.remoteConfig.RemoteConfigTemplate,
   ): Promise<admin.remoteConfig.RemoteConfigTemplate> {
     return this.remoteConfig.validateTemplate(template);
   }
+
   publishTemplate(
     template: admin.remoteConfig.RemoteConfigTemplate,
     options?: { force: boolean },
   ): Promise<admin.remoteConfig.RemoteConfigTemplate> {
     return this.remoteConfig.publishTemplate(template, options);
   }
+  
   createTemplateFromJSON(json: string): admin.remoteConfig.RemoteConfigTemplate {
     return this.remoteConfig.createTemplateFromJSON(json);
   }
+
+  rollback(versionNumber: string | number): Promise<admin.remoteConfig.RemoteConfigTemplate> {
+    return this.remoteConfig.rollback(versionNumber)
+  }
+
+  listVersions(options?: admin.remoteConfig.ListVersionsOptions): Promise<admin.remoteConfig.ListVersionsResult> {
+    return this.remoteConfig.listVersions(options)
+  }
+  
 }


### PR DESCRIPTION
```
export declare class FirebaseRemoteConfigService implements admin.remoteConfig.RemoteConfig {

node_modules/@aginix/nestjs-firebase-admin/dist/services/firebase-admin-remote-config.service.d.ts:2:22 - error 
TS2420: Class 'FirebaseRemoteConfigService' incorrectly implements interface 'RemoteConfig'.
  Type 'FirebaseRemoteConfigService' is missing the following properties from type 'RemoteConfig': getTemplateAtVersion, rollback, listVersions
```